### PR TITLE
add autostart tmux settings

### DIFF
--- a/zsh/zsh_function
+++ b/zsh/zsh_function
@@ -25,6 +25,26 @@ function presh() {
     add-zsh-hook precmd "__precmd_for_presh"
 }
 
+function autostart_tmux() {
+    if [[ ! -n $TMUX && $- == *l* ]]; then
+        # get the IDs
+        ID="`tmux list-sessions`"
+        if [[ -z "$ID" ]]; then
+            tmux new-session
+        fi
+        create_new_session="Create New Session"
+        ID="$ID\n${create_new_session}:"
+        ID="`echo $ID | fzf | cut -d: -f1`"
+        if [[ "$ID" = "${create_new_session}" ]]; then
+            tmux new-session
+        elif [[ -n "$ID" ]]; then
+            tmux attach-session -t "$ID"
+        else
+            :  # Start terminal normally
+        fi
+    fi
+}
+
 # pecoを使ってコマンド履歴を表示する
 function peco-select-history() {
     local tac

--- a/zsh/zsh_function
+++ b/zsh/zsh_function
@@ -34,7 +34,7 @@ function autostart_tmux() {
         fi
         create_new_session="Create New Session"
         ID="$ID\n${create_new_session}:"
-        ID="`echo $ID | fzf | cut -d: -f1`"
+        ID="`echo $ID | ${PERCOL:=fzf} | cut -d: -f1`"
         if [[ "$ID" = "${create_new_session}" ]]; then
             tmux new-session
         elif [[ -n "$ID" ]]; then

--- a/zsh/zshrc
+++ b/zsh/zshrc
@@ -1,6 +1,12 @@
 source $HOME/.zplug/zplug
 source $HOME/.zsh_plugin
 
+source $HOME/.zsh_function
+autostart_tmux
+
+source $HOME/.zsh_alias
+source $HOME/.zsh_keybind
+
 # Source Prezto.
 if [[ -s "${ZDOTDIR:-$HOME}/workspace/project/dotfiles/zsh/zprezto/init.zsh" ]]; then
   source "${ZDOTDIR:-$HOME}/workspace/project/dotfiles/zsh/zprezto/init.zsh"
@@ -60,10 +66,6 @@ setopt ignoreeof
 
 # Ctrl+sを使えるようにする
 stty stop undef
-
-source $HOME/.zsh_alias
-source $HOME/.zsh_function
-source $HOME/.zsh_keybind
 
 # enhancdを読み込む
 if [ -f $ZPLUG_HOME/repos/b4b4r07/enhancd/enhancd.sh ]; then


### PR DESCRIPTION
端末を起動したときに、すでにあるtmux sessionを開くか、新規sessionを開くかを選択できるようにした

環境変数 `PERCOL` で選択する方法を指定する
`PERCOL`が定義済みの場合、定義された方法でsessionを選択する
未定義の場合、`fzf`でsessionを選択する