### PR TITLE
fix internal field separator when use 'git dsf'

### DIFF
--- a/git/gitconfig
+++ b/git/gitconfig
@@ -12,7 +12,7 @@
     cp = cherry-pick
     br = branch
     ba = branch -a
-    dsf = "!f () { git diff --color $@ | diff-so-fancy | less --tabs=4 -RFX; };f"
+    dsf = "!f () { IFS_BACKUP=$IFS; IFS=$'\n'; git diff --color "$@" | diff-so-fancy | less --tabs=4 -RFX; IFS=$IFS_BACKUP; };f"
     rm-br-merged = "!f () { git branch --merged | egrep -v '\\*|develop|master' | xargs git branch -d; };f"
     unstage = reset HEAD
     subadd = "!f () { git subtree add --prefix=${1} ${2} ${3} ;};f"


### PR DESCRIPTION
ref: https://linux.just4fun.biz/?%E9%80%86%E5%BC%95%E3%81%8D%E3%82%B7%E3%82%A7%E3%83%AB%E3%82%B9%E3%82%AF%E3%83%AA%E3%83%97%E3%83%88/%E3%82%B9%E3%83%9A%E3%83%BC%E3%82%B9%E3%81%8C%E5%90%AB%E3%81%BE%E3%82%8C%E3%82%8B%E6%96%87%E5%AD%97%E5%88%97%E3%82%921%E8%A1%8C%E3%81%A8%E3%81%97%E3%81%A6%E6%89%B1%E3%81%86%E6%96%B9%E6%B3%95