### PR TITLE
Integrate Codex CLI into dotfiles with tmux-based skill scripts

### DIFF
--- a/claude/scripts/codex-review.sh
+++ b/claude/scripts/codex-review.sh
@@ -1,0 +1,61 @@
+#!/bin/bash
+
+HEAD_REF="$1"
+BASE_REF="$2"
+
+if [ -z "$HEAD_REF" ] || [ -z "$BASE_REF" ]; then
+  echo "Usage: codex-review.sh <headRefName> <baseRefName>"
+  exit 1
+fi
+
+# 1. tmux チェック
+if ! tmux info &>/dev/null 2>&1; then
+  echo "❌ tmux が起動していないようです。"
+  exit 1
+fi
+
+# 2. Codex pane を検出
+echo "🔍 Codex pane を検索中..."
+PANE_ID=$(tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index} #{pane_current_command}" \
+  | grep codex | head -1 | awk '{print $1}')
+
+# 3. なければ新しい pane で起動
+if [ -z "$PANE_ID" ]; then
+  echo "🚀 Codex pane が見つかりませんでした。新しい pane で起動します..."
+  tmux split-window -h
+  PANE_ID=$(tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index}" | tail -1)
+  tmux send-keys -t "$PANE_ID" "codex" Enter
+  sleep 3
+  echo "✅ Codex を起動しました（pane: $PANE_ID）"
+else
+  echo "✅ Codex pane を検出しました（pane: $PANE_ID）"
+fi
+
+# 4. ユニークなファイルを生成
+MARKER_ID=$(date +%s)
+MARKER_FILE="/tmp/codex_done_${MARKER_ID}"
+REVIEW_FILE="/tmp/codex_review_${MARKER_ID}.md"
+rm -f "$MARKER_FILE" "$REVIEW_FILE"
+echo "📝 レビュー結果ファイル: $REVIEW_FILE"
+
+# 5. レビュー指示を送信
+echo "📤 レビュー指示を送信中..."
+tmux send-keys -t "$PANE_ID" -l "このブランチ（${HEAD_REF}）の ${BASE_REF} に対する変更をレビューしてください。以下の観点で確認してください：(1) コード品質 — 可読性、命名、不要な複雑さ、重複；(2) 潜在的なバグ — 未処理のエッジケース、エラーハンドリング、誤った前提；(3) テストカバレッジ — テスト漏れ、未テストのエッジケース、意味のないアサーション。ファイル名と行番号を具体的に示してください。レビュー結果を ${REVIEW_FILE} に書き出し、完了したら touch ${MARKER_FILE} を実行してください。"
+sleep 0.5
+tmux send-keys -t "$PANE_ID" Enter
+echo "⏳ Codex のレビュー完了を待機中（最大10分）..."
+
+# 6. 完了を polling（3秒おき、最大10分）
+for i in $(seq 1 200); do
+  if [ -f "$MARKER_FILE" ]; then
+    rm -f "$MARKER_FILE"
+    echo "✅ Codex がレビューを完了しました。"
+    cat "$REVIEW_FILE"
+    rm -f "$REVIEW_FILE"
+    exit 0
+  fi
+  sleep 3
+done
+
+echo "⏱️ タイムアウトしました。Codex がまだ作業中の可能性があります。"
+exit 1

--- a/claude/scripts/codex-review.sh
+++ b/claude/scripts/codex-review.sh
@@ -32,9 +32,9 @@ if [ -z "$PANE_ID" ]; then
   PANE_ID=$(tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index}" | tail -1)
   tmux send-keys -t "$PANE_ID" "codex" Enter
   sleep 3
-  echo "✅ Codex を起動しました（pane: $PANE_ID）"
+  echo "✅ Codex を起動しました(pane: $PANE_ID)"
 else
-  echo "✅ Codex pane を検出しました（pane: $PANE_ID）"
+  echo "✅ Codex pane を検出しました(pane: $PANE_ID)"
 fi
 
 # 4. ユニークなファイルを生成
@@ -46,12 +46,12 @@ echo "📝 レビュー結果ファイル: $REVIEW_FILE"
 
 # 5. レビュー指示を送信
 echo "📤 レビュー指示を送信中..."
-tmux send-keys -t "$PANE_ID" -l "${DIFF_FILE} に PR（${HEAD_REF} → ${BASE_REF}）の diff があります。このファイルを読んで以下の観点でレビューしてください：(1) コード品質 — 可読性、命名、不要な複雑さ、重複；(2) 潜在的なバグ — 未処理のエッジケース、エラーハンドリング、誤った前提；(3) テストカバレッジ — テスト漏れ、未テストのエッジケース、意味のないアサーション。ファイル名と行番号を具体的に示してください。レビュー結果を ${REVIEW_FILE} に書き出し、完了したら touch ${MARKER_FILE} を実行してください。"
+tmux send-keys -t "$PANE_ID" -l "${DIFF_FILE} に PR(${HEAD_REF} → ${BASE_REF})の diff があります。このファイルを読んで以下の観点でレビューしてください：(1) コード品質 — 可読性、命名、不要な複雑さ、重複；(2) 潜在的なバグ — 未処理のエッジケース、エラーハンドリング、誤った前提；(3) テストカバレッジ — テスト漏れ、未テストのエッジケース、意味のないアサーション。ファイル名と行番号を具体的に示してください。レビュー結果を ${REVIEW_FILE} に書き出し、完了したら touch ${MARKER_FILE} を実行してください。"
 sleep 0.5
 tmux send-keys -t "$PANE_ID" Enter
-echo "⏳ Codex のレビュー完了を待機中（最大10分）..."
+echo "⏳ Codex のレビュー完了を待機中(最大10分)..."
 
-# 6. 完了を polling（3秒おき、最大10分）
+# 6. 完了を polling(3秒おき、最大10分)
 for i in $(seq 1 200); do
   if [ -f "$MARKER_FILE" ]; then
     rm -f "$MARKER_FILE"

--- a/claude/scripts/codex-review.sh
+++ b/claude/scripts/codex-review.sh
@@ -2,9 +2,15 @@
 
 HEAD_REF="$1"
 BASE_REF="$2"
+DIFF_FILE="$3"
 
-if [ -z "$HEAD_REF" ] || [ -z "$BASE_REF" ]; then
-  echo "Usage: codex-review.sh <headRefName> <baseRefName>"
+if [ -z "$HEAD_REF" ] || [ -z "$BASE_REF" ] || [ -z "$DIFF_FILE" ]; then
+  echo "Usage: codex-review.sh <headRefName> <baseRefName> <diff-file>"
+  exit 1
+fi
+
+if [ ! -f "$DIFF_FILE" ]; then
+  echo "❌ diff ファイルが見つかりません: $DIFF_FILE"
   exit 1
 fi
 
@@ -40,7 +46,7 @@ echo "📝 レビュー結果ファイル: $REVIEW_FILE"
 
 # 5. レビュー指示を送信
 echo "📤 レビュー指示を送信中..."
-tmux send-keys -t "$PANE_ID" -l "このブランチ（${HEAD_REF}）の ${BASE_REF} に対する変更をレビューしてください。以下の観点で確認してください：(1) コード品質 — 可読性、命名、不要な複雑さ、重複；(2) 潜在的なバグ — 未処理のエッジケース、エラーハンドリング、誤った前提；(3) テストカバレッジ — テスト漏れ、未テストのエッジケース、意味のないアサーション。ファイル名と行番号を具体的に示してください。レビュー結果を ${REVIEW_FILE} に書き出し、完了したら touch ${MARKER_FILE} を実行してください。"
+tmux send-keys -t "$PANE_ID" -l "${DIFF_FILE} に PR（${HEAD_REF} → ${BASE_REF}）の diff があります。このファイルを読んで以下の観点でレビューしてください：(1) コード品質 — 可読性、命名、不要な複雑さ、重複；(2) 潜在的なバグ — 未処理のエッジケース、エラーハンドリング、誤った前提；(3) テストカバレッジ — テスト漏れ、未テストのエッジケース、意味のないアサーション。ファイル名と行番号を具体的に示してください。レビュー結果を ${REVIEW_FILE} に書き出し、完了したら touch ${MARKER_FILE} を実行してください。"
 sleep 0.5
 tmux send-keys -t "$PANE_ID" Enter
 echo "⏳ Codex のレビュー完了を待機中（最大10分）..."

--- a/claude/scripts/codex-send.sh
+++ b/claude/scripts/codex-send.sh
@@ -20,9 +20,9 @@ if [ -z "$PANE_ID" ]; then
   PANE_ID=$(tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index}" | tail -1)
   tmux send-keys -t "$PANE_ID" "codex" Enter
   sleep 3
-  echo "✅ Codex を起動しました（pane: $PANE_ID）"
+  echo "✅ Codex を起動しました(pane: $PANE_ID)"
 else
-  echo "✅ Codex pane を検出しました（pane: $PANE_ID）"
+  echo "✅ Codex pane を検出しました(pane: $PANE_ID)"
 fi
 
 # 4. ユニークなマーカーファイルを生成
@@ -37,7 +37,7 @@ sleep 0.5
 tmux send-keys -t "$PANE_ID" Enter
 echo "⏳ Codex の完了を待機中..."
 
-# 6. 完了を polling（3秒おき、最大5分）
+# 6. 完了を polling(3秒おき、最大5分)
 for i in $(seq 1 100); do
   if [ -f "$MARKER_FILE" ]; then
     rm -f "$MARKER_FILE"

--- a/claude/scripts/codex-send.sh
+++ b/claude/scripts/codex-send.sh
@@ -1,0 +1,51 @@
+#!/bin/bash
+
+MESSAGE="$1"
+
+# 1. tmux チェック
+if ! tmux info &>/dev/null 2>&1; then
+  echo "❌ tmux が起動していないようです。"
+  exit 1
+fi
+
+# 2. Codex pane を検出
+echo "🔍 Codex pane を検索中..."
+PANE_ID=$(tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index} #{pane_current_command}" \
+  | grep codex | head -1 | awk '{print $1}')
+
+# 3. なければ新しい pane で起動
+if [ -z "$PANE_ID" ]; then
+  echo "🚀 Codex pane が見つかりませんでした。新しい pane で起動します..."
+  tmux split-window -h
+  PANE_ID=$(tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index}" | tail -1)
+  tmux send-keys -t "$PANE_ID" "codex" Enter
+  sleep 3
+  echo "✅ Codex を起動しました（pane: $PANE_ID）"
+else
+  echo "✅ Codex pane を検出しました（pane: $PANE_ID）"
+fi
+
+# 4. ユニークなマーカーファイルを生成
+MARKER_FILE="/tmp/codex_done_$(date +%s)"
+echo "📝 マーカーファイル: $MARKER_FILE"
+
+# 5. メッセージ送信
+echo "📤 メッセージを送信中..."
+tmux send-keys -t "$PANE_ID" -l "${MESSAGE}
+作業が完了したら \`touch ${MARKER_FILE}\` を実行してください。"
+sleep 0.5
+tmux send-keys -t "$PANE_ID" Enter
+echo "⏳ Codex の完了を待機中..."
+
+# 6. 完了を polling（3秒おき、最大5分）
+for i in $(seq 1 100); do
+  if [ -f "$MARKER_FILE" ]; then
+    rm -f "$MARKER_FILE"
+    echo "✅ Codex が完了しました。"
+    exit 0
+  fi
+  sleep 3
+done
+
+echo "⏱️ タイムアウトしました。Codex がまだ作業中の可能性があります。"
+exit 1

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -28,7 +28,8 @@
       "Bash(cat:*)",
       "Bash(date:*)",
       "Bash(sleep:*)",
-      "Bash(seq:*)"
+      "Bash(seq:*)",
+      "Bash(~/.claude/scripts/codex-send.sh:*)"
     ],
     "deny": [
       "Bash(rm -rf:*)"

--- a/claude/settings.json
+++ b/claude/settings.json
@@ -20,16 +20,8 @@
       "Bash(xcrun simctl boot:*)",
       "Bash(xcodebuild test:*)",
       "Bash(./gradlew ktlintFormat:*)",
-      "Bash(tmux list-panes:*)",
-      "Bash(tmux send-keys:*)",
-      "Bash(tmux split-window:*)",
-      "Bash(rm -f /tmp/codex_done_*:*)",
-      "Bash(rm -f /tmp/codex_review_*:*)",
-      "Bash(cat:*)",
-      "Bash(date:*)",
-      "Bash(sleep:*)",
-      "Bash(seq:*)",
-      "Bash(~/.claude/scripts/codex-send.sh:*)"
+      "Bash(~/.claude/scripts/codex-send.sh:*)",
+      "Bash(~/.claude/scripts/codex-review.sh:*)"
     ],
     "deny": [
       "Bash(rm -rf:*)"

--- a/claude/skills/codex-send/SKILL.md
+++ b/claude/skills/codex-send/SKILL.md
@@ -22,5 +22,5 @@ description: Send an instruction to Codex running in a tmux pane. Use this skill
 2. **Confirm to the user**
 
    - If the script outputs `✅ Codex が完了しました。`: inform the user and proceed to the next message if any.
-   - If the script outputs `⏱️ タイムアウト...`: inform the user that Codex may still be working.
+   - If the script outputs `⏱️ タイムアウトしました。Codex がまだ作業中の可能性があります。`: inform the user that Codex may still be working.
    - If the script outputs `❌ tmux が起動していないようです。`: inform the user and stop.

--- a/claude/skills/codex-send/SKILL.md
+++ b/claude/skills/codex-send/SKILL.md
@@ -6,86 +6,21 @@ description: Send an instruction to Codex running in a tmux pane. Use this skill
 
 ## Rules
 
-- Always auto-detect the Codex pane from tmux. Never ask the user for the pane ID.
-- Use `-l` flag with `tmux send-keys` to send text as literal characters.
-- Always insert `sleep 0.5` between sending the text and sending Enter.
-- Send one message at a time. If multiple messages are requested, send them sequentially — wait for completion detection before sending the next one.
-- Always append the completion notification instruction to the message before sending.
+- Send one message at a time. If multiple messages are requested, send them sequentially — wait for completion before sending the next one.
 
 ## Steps
 
-1. **Detect the Codex pane**
+1. **Send the message**
 
    Run:
    ```
-   tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index} #{pane_current_command}"
+   ~/.claude/scripts/codex-send.sh "<message>"
    ```
 
-   - If the command fails (non-zero exit code), inform the user: "tmux が起動していないようです。" and stop.
-   - If the command succeeds but no pane's `pane_current_command` contains `codex`, proceed to step 2 to launch Codex in a new pane.
-   - Otherwise, use the matched pane ID (e.g., `0:3.2`) and skip to step 3.
+   The script handles pane detection, Codex launch if needed, message sending, and completion polling automatically.
 
-2. **Launch Codex in a new pane** _(only if no Codex pane was found)_
+2. **Confirm to the user**
 
-   Run the following to split the current window and start Codex:
-   ```
-   tmux split-window -h -t {current}
-   ```
-
-   Then get the new pane's ID:
-   ```
-   tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index} #{pane_current_command}" | tail -1
-   ```
-
-   Start Codex in that pane:
-   ```
-   tmux send-keys -t <new-pane-id> "codex" Enter
-   ```
-
-   Wait for Codex to start up:
-   ```
-   sleep 3
-   ```
-
-   Inform the user: "Codex が起動していなかったため、新しい pane で起動しました。"
-
-3. **Generate a unique marker ID**
-
-   Generate a unique ID using the current timestamp:
-   ```
-   MARKER_ID=$(date +%s)
-   MARKER_FILE="/tmp/codex_done_${MARKER_ID}"
-   ```
-
-4. **Send the message**
-
-   Append the following to the user's message before sending:
-   > 「作業が完了したら `touch /tmp/codex_done_<MARKER_ID>` を実行してください。」
-
-   Then send:
-   ```
-   tmux send-keys -t <pane-id> -l "<message>\n作業が完了したら `touch /tmp/codex_done_<MARKER_ID>` を実行してください。"
-   sleep 0.5
-   tmux send-keys -t <pane-id> Enter
-   ```
-
-5. **Wait for completion**
-
-   Poll for the specific marker file every 3 seconds, with a timeout of 5 minutes:
-   ```bash
-   for i in $(seq 1 100); do
-     if [ -f "$MARKER_FILE" ]; then
-       rm -f "$MARKER_FILE"
-       echo "done"
-       break
-     fi
-     sleep 3
-   done
-   ```
-
-   - If the file appears: inform the user "✅ Codex が完了しました。" and proceed to the next message if any.
-   - If the timeout is reached (100 × 3s = 5 minutes): inform the user "⏱️ タイムアウトしました。Codex がまだ作業中の可能性があります。" and stop polling.
-
-6. **Confirm to the user**
-
-   Tell the user the result and, if multiple messages were queued, send the next one.
+   - If the script outputs `✅ Codex が完了しました。`: inform the user and proceed to the next message if any.
+   - If the script outputs `⏱️ タイムアウト...`: inform the user that Codex may still be working.
+   - If the script outputs `❌ tmux が起動していないようです。`: inform the user and stop.

--- a/claude/skills/review-pr/SKILL.md
+++ b/claude/skills/review-pr/SKILL.md
@@ -34,52 +34,12 @@ description: Reviews a GitHub Pull Request. Use this skill when the user asks to
 
    **Codex review task** _(skip only if tmux is not running)_:
 
-   1. Detect the Codex pane:
-      ```
-      tmux list-panes -a -F "#{session_name}:#{window_index}.#{pane_index} #{pane_current_command}"
-      ```
-      Use the pane whose `pane_current_command` contains `codex`. If none found, launch Codex in a new pane:
-      ```
-      tmux split-window -h -t {current}
-      tmux send-keys -t <new-pane-id> "codex" Enter
-      sleep 3
-      ```
-      Then use that new pane ID.
+   Run:
+   ```
+   ~/.claude/scripts/codex-review.sh <headRefName> <baseRefName>
+   ```
 
-   2. Generate unique IDs for the marker and output files:
-      ```
-      MARKER_ID=$(date +%s)
-      MARKER_FILE="/tmp/codex_done_${MARKER_ID}"
-      REVIEW_FILE="/tmp/codex_review_${MARKER_ID}.md"
-      rm -f "$MARKER_FILE" "$REVIEW_FILE"
-      ```
-
-   3. Send the review instruction to the Codex pane:
-      ```
-      tmux send-keys -t <pane-id> -l "このブランチ（<headRefName>）の <baseRefName> に対する変更をレビューしてください。以下の観点で確認してください：(1) コード品質 — 可読性、命名、不要な複雑さ、重複；(2) 潜在的なバグ — 未処理のエッジケース、エラーハンドリング、誤った前提；(3) テストカバレッジ — テスト漏れ、未テストのエッジケース、意味のないアサーション。ファイル名と行番号を具体的に示してください。レビュー結果を /tmp/codex_review_<MARKER_ID>.md に書き出し、完了したら touch /tmp/codex_done_<MARKER_ID> を実行してください。"
-      sleep 0.5
-      tmux send-keys -t <pane-id> Enter
-      ```
-
-   4. Poll for completion (timeout: 10 minutes):
-      ```bash
-      for i in $(seq 1 200); do
-        if [ -f "$MARKER_FILE" ]; then
-          rm -f "$MARKER_FILE"
-          break
-        fi
-        sleep 3
-      done
-      ```
-
-   5. Read Codex findings from the output file:
-      ```
-      cat "$REVIEW_FILE"
-      ```
-      Store the content as **Codex findings**. Then remove the file:
-      ```
-      rm -f "$REVIEW_FILE"
-      ```
+   The script handles pane detection, Codex launch if needed, instruction sending, polling, and file cleanup automatically. Store the stdout as **Codex findings**.
 
 
    Claude review dimensions:

--- a/claude/skills/review-pr/SKILL.md
+++ b/claude/skills/review-pr/SKILL.md
@@ -10,7 +10,6 @@ description: Reviews a GitHub Pull Request. Use this skill when the user asks to
 - Never post comments to the PR unless explicitly requested by the user.
 - Always display results in the terminal.
 - Focus on code quality, potential bugs, and test coverage.
-- Always restore the original branch after checking out a PR.
 
 ## Steps
 
@@ -23,24 +22,13 @@ description: Reviews a GitHub Pull Request. Use this skill when the user asks to
 2. **Fetch PR information** — run the following in parallel:
 
    - `gh pr view <pr-number> --json title,body,baseRefName,headRefName,author,additions,deletions,changedFiles`
-   - `gh pr diff <pr-number>` to get the full diff
-   - `git branch --show-current` to record the current branch so it can be restored later
+   - `gh pr diff <pr-number>` to get the full diff, and write it to `/tmp/pr_diff_<pr-number>.diff`
 
 3. **Run reviews in parallel**
 
    Launch both reviewers at the same time using the Task tool:
 
    **Claude review task**: Analyze the diff obtained in step 2 across the three dimensions below. Store results as **Claude findings**.
-
-   **Codex review task** _(skip only if tmux is not running)_:
-
-   Run:
-   ```
-   ~/.claude/scripts/codex-review.sh <headRefName> <baseRefName>
-   ```
-
-   The script handles pane detection, Codex launch if needed, instruction sending, polling, and file cleanup automatically. Store the stdout as **Codex findings**.
-
 
    Claude review dimensions:
 
@@ -62,6 +50,15 @@ description: Reviews a GitHub Pull Request. Use this skill when the user asks to
    - Are edge cases and error paths tested?
    - Do existing tests still make sense after the change?
    - Are tests meaningful (not just asserting trivially true things)?
+
+   **Codex review task** _(skip only if tmux is not running)_:
+
+   Run:
+   ```
+   ~/.claude/scripts/codex-review.sh <headRefName> <baseRefName> /tmp/pr_diff_<pr-number>.diff
+   ```
+
+   The script handles pane detection, Codex launch if needed, instruction sending, polling, and file cleanup automatically. Store the stdout as **Codex findings**.
 
 4. **Consolidate and output**
 


### PR DESCRIPTION
## Summary

- Codex CLI の設定ファイル（AGENTS.md、skills）を dotfiles に追加し、setting.sh/clean.sh で一元管理できるようにした
- `codex-send` スキルを新規追加：tmux の Codex pane を自動検出し、マーカーファイルによる完了検知付きでメッセージを送信する
- `codex-send.sh` / `codex-review.sh` シェルスクリプトを追加：pane 検出・Codex 起動・メッセージ送信・完了ポーリングのロジックを集約
- `review-pr` スキルを更新：Codex レビューを tmux 経由で実行し、diff をファイル経由で渡してレビュー結果をファイルから取得する
- `pr` スキルを更新：Assignee に「自分」を指定した場合、`gh api user` で GitHub ユーザー名を自動解決する
- Claude Code の settings.json に Codex プラグイン登録とスクリプト実行パーミッションを追加

## Test plan

- [ ] `codex/setting.sh` を実行して `~/.codex/AGENTS.md` と `~/.codex/skills` のシンボリックリンクが作成されること
- [ ] `codex-send` スキルで Codex pane が存在しない場合に自動起動されること
- [ ] `codex-send` スキルでメッセージ送信後、マーカーファイルが作成されると完了通知が表示されること
- [ ] `review-pr` スキルで diff ファイルが生成され、Codex がそれを読んでレビュー結果を出力すること